### PR TITLE
docs(ui): add component documentation

### DIFF
--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -1,0 +1,50 @@
+# Button
+
+The `Button` component renders a native `button` element.
+
+## Props
+
+```ts
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Content to display inside the button.
+   */
+  children: React.ReactNode;
+}
+```
+
+In addition to the props above, all standard HTML button attributes are supported.
+
+## Examples
+
+### Basic
+
+```tsx
+import { Button } from "@ackplus/ui";
+
+export default function Example() {
+  return <Button>Click me</Button>;
+}
+```
+
+### Advanced
+
+```tsx
+import * as React from "react";
+import { Button } from "@ackplus/ui";
+
+export default function AdvancedExample() {
+  const [count, setCount] = React.useState(0);
+
+  return (
+    <Button disabled={count >= 5} onClick={() => setCount(count + 1)}>
+      Clicked {count} times
+    </Button>
+  );
+}
+```
+
+## Accessibility
+
+- Provide accessible text via the `children` or `aria-label` prop.
+- Ensure disabled buttons have an alternative means of activation.

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,0 +1,4 @@
+# Components
+
+- [Button](./button.mdx)
+- [ThemeProvider](./theme-provider.mdx)

--- a/docs/components/theme-provider.mdx
+++ b/docs/components/theme-provider.mdx
@@ -1,0 +1,53 @@
+# ThemeProvider
+
+The `ThemeProvider` wraps its children without adding extra markup and can be used for theming context.
+
+## Props
+
+```ts
+interface ThemeProviderProps {
+  /**
+   * Elements to render within the provider.
+   */
+  children: React.ReactNode;
+}
+```
+
+## Examples
+
+### Basic
+
+```tsx
+import { ThemeProvider, Button } from "@ackplus/ui";
+
+export default function Example() {
+  return (
+    <ThemeProvider>
+      <Button>Save</Button>
+    </ThemeProvider>
+  );
+}
+```
+
+### Advanced
+
+```tsx
+import { ThemeProvider } from "@ackplus/ui";
+
+export default function NestedExample() {
+  return (
+    <ThemeProvider>
+      <section>
+        <p>Default theme</p>
+        <ThemeProvider>
+          <p>Nested provider content</p>
+        </ThemeProvider>
+      </section>
+    </ThemeProvider>
+  );
+}
+```
+
+## Accessibility
+
+The `ThemeProvider` does not render any DOM elements and has no direct accessibility concerns.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,3 +1,7 @@
 # @ackplus/ui
 
 UI components for Ackplus.
+
+## Documentation
+
+Component documentation is available in the [docs/components](../../docs/components) directory.


### PR DESCRIPTION
## Summary
- document Button and ThemeProvider components with usage examples and accessibility notes
- link component docs from a central index
- reference docs from the UI package README

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68be5e8036948330af7978aa67391a61